### PR TITLE
Bump axios version to 0.19.0 closes #1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.1.0.tgz",
       "integrity": "sha1-A1UaXH8O371PyPoSpoFJeOq2UcM=",
       "requires": {
-        "exit-on-epipe": "1.0.1",
-        "printj": "1.1.2"
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
       }
     },
     "ansi-regex": {
@@ -23,7 +23,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "any-promise": {
@@ -32,12 +32,27 @@
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
       "requires": {
-        "follow-redirects": "1.5.8",
-        "is-buffer": "1.1.6"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        }
       }
     },
     "cfb": {
@@ -45,8 +60,8 @@
       "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.0.8.tgz",
       "integrity": "sha1-d/ITST1pfXVP2cD1UR6rWtctAs8=",
       "requires": {
-        "commander": "2.18.0",
-        "printj": "1.1.2"
+        "commander": "^2.14.1",
+        "printj": "~1.1.2"
       }
     },
     "chalk": {
@@ -54,9 +69,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chardet": {
@@ -69,7 +84,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-spinners": {
@@ -87,9 +102,9 @@
       "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.11.1.tgz",
       "integrity": "sha1-hkcjl+pbLNuwe3cBalEkd6PLiCM=",
       "requires": {
-        "commander": "2.11.0",
-        "exit-on-epipe": "1.0.1",
-        "voc": "1.0.0"
+        "commander": "~2.11.0",
+        "exit-on-epipe": "~1.0.1",
+        "voc": "~1.0.0"
       },
       "dependencies": {
         "commander": {
@@ -122,8 +137,8 @@
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.1.1.tgz",
       "integrity": "sha1-XXOdXkxuNSrYME1zIj1IP+Va240=",
       "requires": {
-        "exit-on-epipe": "1.0.1",
-        "printj": "1.1.2"
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
       }
     },
     "csv": {
@@ -131,10 +146,10 @@
       "resolved": "https://registry.npmjs.org/csv/-/csv-1.2.1.tgz",
       "integrity": "sha1-UjHt/BxxUlEuxFeBB2p6l/9SXAw=",
       "requires": {
-        "csv-generate": "1.1.2",
-        "csv-parse": "1.3.3",
-        "csv-stringify": "1.1.2",
-        "stream-transform": "0.2.2"
+        "csv-generate": "^1.1.2",
+        "csv-parse": "^1.3.3",
+        "csv-stringify": "^1.1.2",
+        "stream-transform": "^0.2.2"
       }
     },
     "csv-generate": {
@@ -157,7 +172,7 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.1.2.tgz",
       "integrity": "sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=",
       "requires": {
-        "lodash.get": "4.4.2"
+        "lodash.get": "~4.4.2"
       }
     },
     "d3-time": {
@@ -170,7 +185,7 @@
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-0.3.2.tgz",
       "integrity": "sha1-nDDpCkB4+T+sFeJ7IBaGVIjAB8E=",
       "requires": {
-        "d3-time": "0.2.6"
+        "d3-time": "~0.2.0"
       }
     },
     "data.js": {
@@ -178,17 +193,17 @@
       "resolved": "https://registry.npmjs.org/data.js/-/data.js-0.11.5.tgz",
       "integrity": "sha1-5trf05CewvEnp3PEObE83X8+WBA=",
       "requires": {
-        "chardet": "0.4.2",
-        "csv-parse": "1.3.3",
-        "csv-sniffer": "0.1.1",
-        "iconv-lite": "0.4.24",
-        "lodash": "4.17.11",
-        "mime-types": "2.1.20",
-        "node-fetch": "2.2.0",
-        "stream-to-array": "2.3.0",
-        "stream-to-string": "1.1.0",
-        "tableschema": "1.9.1",
-        "url-join": "2.0.5",
+        "chardet": "^0.4.2",
+        "csv-parse": "^1.2.1",
+        "csv-sniffer": "^0.1.1",
+        "iconv-lite": "^0.4.19",
+        "lodash": "^4.17.4",
+        "mime-types": "^2.1.16",
+        "node-fetch": "^2.0.0",
+        "stream-to-array": "^2.3.0",
+        "stream-to-string": "^1.1.0",
+        "tableschema": "^1.9.0",
+        "url-join": "^2.0.2",
         "xlsx": "0.11.8"
       }
     },
@@ -205,7 +220,7 @@
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "requires": {
-        "clone": "1.0.4"
+        "clone": "^1.0.2"
       }
     },
     "es6-error": {
@@ -228,7 +243,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
       "integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
       "requires": {
-        "debug": "3.1.0"
+        "debug": "=3.1.0"
       }
     },
     "frac": {
@@ -246,7 +261,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "is-buffer": {
@@ -269,7 +284,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "requires": {
-        "chalk": "2.4.1"
+        "chalk": "^2.0.1"
       }
     },
     "mime-db": {
@@ -282,7 +297,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
-        "mime-db": "1.36.0"
+        "mime-db": "~1.36.0"
       }
     },
     "mimic-fn": {
@@ -310,7 +325,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "ora": {
@@ -318,12 +333,12 @@
       "resolved": "https://registry.npmjs.org/ora/-/ora-3.0.0.tgz",
       "integrity": "sha512-LBS97LFe2RV6GJmXBi6OKcETKyklHNMV0xw7BtsVn2MlsgsydyZetSCbCANr+PFLmDyv4KV88nn0eCKza665Mg==",
       "requires": {
-        "chalk": "2.4.1",
-        "cli-cursor": "2.1.0",
-        "cli-spinners": "1.3.1",
-        "log-symbols": "2.2.0",
-        "strip-ansi": "4.0.0",
-        "wcwidth": "1.0.1"
+        "chalk": "^2.3.1",
+        "cli-cursor": "^2.1.0",
+        "cli-spinners": "^1.1.0",
+        "log-symbols": "^2.2.0",
+        "strip-ansi": "^4.0.0",
+        "wcwidth": "^1.0.1"
       }
     },
     "printj": {
@@ -346,8 +361,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "safer-buffer": {
@@ -360,11 +375,11 @@
       "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
       "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
       "requires": {
-        "should-equal": "2.0.0",
-        "should-format": "3.0.3",
-        "should-type": "1.4.0",
-        "should-type-adaptors": "1.1.0",
-        "should-util": "1.0.0"
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
       }
     },
     "should-equal": {
@@ -372,7 +387,7 @@
       "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
       "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
       "requires": {
-        "should-type": "1.4.0"
+        "should-type": "^1.4.0"
       }
     },
     "should-format": {
@@ -380,8 +395,8 @@
       "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
       "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
       "requires": {
-        "should-type": "1.4.0",
-        "should-type-adaptors": "1.1.0"
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
       }
     },
     "should-type": {
@@ -394,8 +409,8 @@
       "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
       "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
       "requires": {
-        "should-type": "1.4.0",
-        "should-util": "1.0.0"
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
       }
     },
     "should-util": {
@@ -413,7 +428,7 @@
       "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.10.2.tgz",
       "integrity": "sha512-rDhAPm9WyIsY8eZEKyE8Qsotb3j/wBdvMWBUsOhJdfhKGLfQidRjiBUV0y/MkyCLiXQ38FG6LWW/VYUtqlIDZQ==",
       "requires": {
-        "frac": "1.1.2"
+        "frac": "~1.1.2"
       }
     },
     "stream-to-array": {
@@ -421,7 +436,7 @@
       "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
       "integrity": "sha1-u/azn19D7DC8cbq8s3VXrOzzQ1M=",
       "requires": {
-        "any-promise": "1.3.0"
+        "any-promise": "^1.1.0"
       }
     },
     "stream-to-async-iterator": {
@@ -434,7 +449,7 @@
       "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.1.0.tgz",
       "integrity": "sha1-OSELATF+ars16FRTjgEwN7ajWUA=",
       "requires": {
-        "promise-polyfill": "1.1.6"
+        "promise-polyfill": "^1.1.6"
       }
     },
     "stream-transform": {
@@ -447,7 +462,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "^3.0.0"
       }
     },
     "supports-color": {
@@ -455,7 +470,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "tableschema": {
@@ -463,17 +478,17 @@
       "resolved": "https://registry.npmjs.org/tableschema/-/tableschema-1.9.1.tgz",
       "integrity": "sha512-OEloAB2pNoF7P53owULF9O6fkny1ippNxREMDIlTlJ3YgrSrlDAQtawnYNowg2bAnzrsgvcPRduZSryQdF/leQ==",
       "requires": {
-        "axios": "0.17.1",
-        "csv": "1.2.1",
-        "csv-sniffer": "0.1.1",
-        "d3-time-format": "0.3.2",
-        "es6-error": "4.1.1",
-        "lodash": "4.17.11",
-        "moment": "2.21.0",
-        "regenerator-runtime": "0.11.1",
-        "stream-to-async-iterator": "0.2.0",
-        "tv4": "1.3.0",
-        "validator": "9.4.1"
+        "axios": "^0.17.1",
+        "csv": "^1.1.1",
+        "csv-sniffer": "^0.1.1",
+        "d3-time-format": "^0.3.2",
+        "es6-error": "^4.0.2",
+        "lodash": "^4.13.1",
+        "moment": "~2.21.0",
+        "regenerator-runtime": "^0.11.0",
+        "stream-to-async-iterator": "^0.2.0",
+        "tv4": "^1.2.7",
+        "validator": "^9.2.0"
       },
       "dependencies": {
         "axios": {
@@ -481,8 +496,8 @@
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
           "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
           "requires": {
-            "follow-redirects": "1.5.8",
-            "is-buffer": "1.1.6"
+            "follow-redirects": "^1.2.5",
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -512,7 +527,7 @@
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "requires": {
-        "defaults": "1.0.3"
+        "defaults": "^1.0.3"
       }
     },
     "xlsx": {
@@ -520,13 +535,13 @@
       "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.11.8.tgz",
       "integrity": "sha1-LsGWnfHrbSOgFqjuHMfG+XD+1Xk=",
       "requires": {
-        "adler-32": "1.1.0",
-        "cfb": "1.0.8",
-        "codepage": "1.11.1",
-        "commander": "2.11.0",
-        "crc-32": "1.1.1",
-        "exit-on-epipe": "1.0.1",
-        "ssf": "0.10.2"
+        "adler-32": "~1.1.0",
+        "cfb": "~1.0.0",
+        "codepage": "~1.11.0",
+        "commander": "~2.11.0",
+        "crc-32": "~1.1.1",
+        "exit-on-epipe": "~1.0.1",
+        "ssf": "~0.10.1"
       },
       "dependencies": {
         "commander": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "Taylor Sturtz",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.19.0",
     "chalk": "^2.4.1",
     "commander": "^2.18.0",
     "data.js": "^0.11.5",


### PR DESCRIPTION
PR to bump axios version to 0.19.0. 

Picked up the issue of githubs issue finder for Hacktoberfest.  Have ran the existing tests and they currently all pass.