### PR TITLE
Fix flag country code

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ const datahub = 'https://datahub.io/core/country-list/datapackage.json';
           if (program.flags) {
             return {
               ...obj,
-              flag: country.Code
+              flag: (country.Code ? country.Code.toLowerCase() : '')
             }
           }
           return obj;


### PR DESCRIPTION
Sorry, never done a fix like this, so maybe I'm doing this all wrong, but I was just testing this country package, and realized that none of the flags were working: my console filled with following kind of warnings. After I changed one flag value to lowercase, that flag immediately started to work and warning disappeared. So, I though there was a bug in this code and tried to fix that on the fly with zero testing in hope of a new version

Warning: Failed prop type: Invalid prop `name` of value `AX` supplied to `Flag`.

Instead of `AX`, did you mean:
  - ad
  - ae
  - af

    in Flag (created by DropdownItem)
    in DropdownItem (created by Dropdown)
    in div (created by DropdownMenu)
    in DropdownMenu (created by Dropdown)
    in div (created by Dropdown)
    in RefFindNode (created by Ref)
    in Ref (created by Dropdown)
    in Dropdown (at App.js:477)
    in div (created by GridRow)
    in GridRow (at App.js:461)
    in div (created by GridColumn)
    in GridColumn (at App.js:457)
    in div (created by Grid)
    in Grid (at App.js:451)
    in div (at App.js:448)
    in App (at src/index.js:13)